### PR TITLE
Add support for resource inventories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.lein-failures
+.lein*
 .nrepl-port
 cucumber.json
 pom.xml*

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject fundingcircle/jukebox "1.0.3"
+(defproject fundingcircle/jukebox "1.0.4-SNAPSHOT"
   :description "A clojure BDD library that integrates with cucumber."
   :url "https://github.com/fundingcircle/jukebox/"
   :license {:name "BSD 3-clause"

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,8 @@
                  [io.cucumber/cucumber-junit "4.2.0"]
                  [org.clojure/clojure "1.10.0" :scope "provided"]
                  [org.clojure/tools.logging "0.4.1"]
-                 [org.clojure/tools.namespace "0.2.11"]]
+                 [org.clojure/tools.namespace "0.2.11"]
+                 [venantius/yagni "0.1.7"]]
   :profiles {:dev {:aliases {"cucumber" ["run" "-m" "cucumber.api.cli.Main"
                                          "--glue" "test/example"
                                          "--plugin" "json:cucumber.json"

--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,9 @@
   :url "https://github.com/fundingcircle/jukebox/"
   :license {:name "BSD 3-clause"
             :url "http://opensource.org/licenses/BSD-3-Clause"}
-  :dependencies [[io.cucumber/cucumber-core "4.2.0"]
-                 [io.cucumber/cucumber-junit "4.2.0"]
-                 [org.clojure/clojure "1.10.0" :scope "provided"]
+  :dependencies [[io.cucumber/cucumber-core "4.2.2"]
+                 [io.cucumber/cucumber-junit "4.2.2"]
+                 [org.clojure/clojure "1.9.0"]
                  [org.clojure/tools.logging "0.4.1"]
                  [org.clojure/tools.namespace "0.2.11"]
                  [venantius/yagni "0.1.7"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject fundingcircle/jukebox "1.0.4-SNAPSHOT"
+(defproject fundingcircle/jukebox "1.0.4"
   :description "A clojure BDD library that integrates with cucumber."
   :url "https://github.com/fundingcircle/jukebox/"
   :license {:name "BSD 3-clause"

--- a/src/fundingcircle/jukebox.clj
+++ b/src/fundingcircle/jukebox.clj
@@ -81,7 +81,7 @@
              [clojure.tools.logging :as log]
              [clojure.tools.namespace.find :as find]))
 
-(defn- scene-related?
+(defn scene-related?
   "Checks whether a var is tagged with any scene related metadata."
   [v]
   (->> (meta v)

--- a/src/fundingcircle/jukebox/resource.clj
+++ b/src/fundingcircle/jukebox/resource.clj
@@ -1,0 +1,37 @@
+(ns fundingcircle.jukebox.resource
+  "Library for creating an inventory of resources needed to run tests."
+  (:require [fundingcircle.jukebox :as jukebox]
+            [yagni.core :as yagni]))
+
+(defn- flattened-call-graph
+  "Given a step definition, returns the set of all functions that are
+  called by it, transitively."
+  [step call-graphs]
+  (let [called-fns (call-graphs step)]
+    (when (seq called-fns)
+      (apply concat
+             called-fns
+             (map #(flattened-call-graph % call-graphs) called-fns)))))
+
+(defn- resources
+  "Returns the resources a fn is tagged with."
+  [v]
+  (when (symbol? v)
+    (let [r (-> (resolve v)
+                (meta)
+                (select-keys [:scene/resource-type :scene/resource-caps]))]
+      (when-not (empty? r)
+        r))))
+
+(defn inventory
+  "Scans the paths for step definitions, and generates a map of step
+  definitions to resource inventory."
+  [source-paths]
+  (let [cg  @(yagni/construct-reference-graph source-paths)]
+    (->> cg
+         (keep (fn [[f _]]
+                 (if-let [fcg (flattened-call-graph f cg)]
+                   [f fcg])))
+         (map (fn [[f calls]] [f (into #{(resources f)}
+                                       (keep resources calls))]))
+         (into {}))))

--- a/src/fundingcircle/jukebox/resource.clj
+++ b/src/fundingcircle/jukebox/resource.clj
@@ -1,37 +1,96 @@
 (ns fundingcircle.jukebox.resource
   "Library for creating an inventory of resources needed to run tests."
   (:require [fundingcircle.jukebox :as jukebox]
-            [yagni.core :as yagni]))
+            [yagni.graph :as graph]
+            [yagni.jvm :as jvm]
+            [yagni.namespace :as namesp]
+            [yagni.namespace.form :as form]))
 
 (defn- flattened-call-graph
   "Given a step definition, returns the set of all functions that are
   called by it, transitively."
-  [step call-graphs]
-  (let [called-fns (call-graphs step)]
-    (when (seq called-fns)
-      (apply concat
-             called-fns
-             (map #(flattened-call-graph % call-graphs) called-fns)))))
+  ([step call-graphs]
+   (flattened-call-graph step call-graphs (atom #{})))
+  ([step call-graphs visited]
+   (when-not (@visited step)
+     (swap! visited conj step)
+     (let [called-fns (->> (call-graphs step)
+                           (remove #{(find-ns 'clojure.core)
+                                     (find-ns 'clojure.spec.alpha)}))]
+       (when (seq called-fns)
+         (apply concat
+                called-fns
+                (map #(flattened-call-graph % call-graphs visited) called-fns)))))))
+
+(defn- ->var
+  "Ensures that `s` is a var."
+  [s]
+  (if (symbol? s)
+    (resolve s)
+    s))
+
+(defn- ->sym
+  "Ensures that `v` is a symbol."
+  [v]
+  (if (symbol? v)
+    v
+    (symbol (str v))))
 
 (defn- resources
-  "Returns the resources a fn is tagged with."
-  [v]
-  (when (symbol? v)
-    (let [r (-> (resolve v)
-                (meta)
-                (select-keys [:scene/resource-type :scene/resource-caps]))]
-      (when-not (empty? r)
-        r))))
+  "If the meta on `v` contains any of the `keys`, returns the meta."
+  [v keys]
+  (let [m (meta (->var v))]
+    (when-not (empty? (select-keys m keys))
+      m)))
+
+(defn- count-vars-in-ns
+  "Calls `yagni.namespace.form/count-vars-in-ns`, ignoring unparsable
+  namespaces."
+  [graph ns]
+  ;; The `potemkin` library attempts to "fix" various clojure problems
+  ;; in ways that break the `macro-expand-1` call that `yagni`
+  ;; makes. Ignoring namespaces that are built with potemkin (or are
+  ;; unparsable for other reasons) seems fine for the moment, for the
+  ;; purposes of the feature this code is providing.
+  (try
+    (form/count-vars-in-ns graph ns)
+    (catch Throwable _)))
+
+(defn- call-graph
+  "Returns the call graph of every var in each of the namespaces."
+  [namespaces]
+  ;; This is the same as `yagni.core/construct-reference-graph`, but
+  ;; with a couple of tweaks:
+  ;;  - Instead of acting on a directory, it acts on a list of namespaces
+  ;;  - `count-vars-in-ns` is overridden (above) to ignore unparsable namespaces
+  (let [namespaces (->> (map ->sym namespaces)
+                        (remove #{'clojure.core}))
+        graph (atom (namesp/named-vars-map namespaces))
+        generator-fns (jvm/find-generator-fns graph)]
+    (jvm/extend-generators! graph generator-fns)
+    ;; (form/count-vars graph namespaces)
+    (doall (map (partial count-vars-in-ns graph) namespaces))
+    (graph/prune-findable-nodes! graph nil (atom #{}))
+    (jvm/compress-generators! graph generator-fns)
+    @graph))
+
+(defn- manifest
+  "Returns a fn that obtains the inventory 'manifest' for a given var."
+  [call-graph keys]
+  (fn [[f]]
+    (when (jukebox/scene-related? (->var f))
+      (when-let [fcg (flattened-call-graph f call-graph)]
+        (let [r (resources f keys)]
+          [f (into (if r #{r} #{})
+                   (keep #(resources % keys) fcg))])))))
 
 (defn inventory
-  "Scans the paths for step definitions, and generates a map of step
-  definitions to resource inventory."
-  [source-paths]
-  (let [cg  @(yagni/construct-reference-graph source-paths)]
-    (->> cg
-         (keep (fn [[f _]]
-                 (if-let [fcg (flattened-call-graph f cg)]
-                   [f fcg])))
-         (map (fn [[f calls]] [f (into #{(resources f)}
-                                       (keep resources calls))]))
+  "Returns a map of entry points to inventory manifest.
+
+  Scans the paths for fn's with meta containing `keys` as entry
+  points. Then scans each's entrypoint's call graph transitively,
+  looking for fns also tagged with `keys` in their 'meta'."
+  [keys]
+  (let [cg (call-graph (all-ns))]
+    (->> (keep (manifest cg keys) cg)
          (into {}))))

--- a/src/fundingcircle/jukebox/resource.clj
+++ b/src/fundingcircle/jukebox/resource.clj
@@ -1,10 +1,26 @@
 (ns fundingcircle.jukebox.resource
   "Library for creating an inventory of resources needed to run tests."
   (:require [fundingcircle.jukebox :as jukebox]
+            [fundingcircle.jukebox.backend.cucumber :as cucumber]
             [yagni.graph :as graph]
             [yagni.jvm :as jvm]
             [yagni.namespace :as namesp]
-            [yagni.namespace.form :as form]))
+            [yagni.namespace.form :as form])
+  (:import cucumber.runtime.FeaturePathFeatureSupplier
+           cucumber.runtime.io.MultiLoader
+           cucumber.runtime.model.FeatureLoader))
+
+(defn surrounding-step?
+  "Checks whether a var is a surrounding step fn (:scene/before, :scene/after,
+  :scene/before-step, or :scene/after-step)."
+  [v]
+  (let [step? (->> (meta v)
+                   (keys)
+                   (some #{:scene/before
+                           :scene/after
+                           :scene/before-step
+                           :scene/after-step}))]
+    (when step? v)))
 
 (defn- flattened-call-graph
   "Given a step definition, returns the set of all functions that are
@@ -43,22 +59,24 @@
     (when-not (empty? (select-keys m keys))
       m)))
 
-(defn- count-vars-in-ns
-  "Calls `yagni.namespace.form/count-vars-in-ns`, ignoring unparsable
-  namespaces."
-  [graph ns]
-  ;; The `potemkin` library attempts to "fix" various clojure problems
-  ;; in ways that break the `macro-expand-1` call that `yagni`
-  ;; makes. Ignoring namespaces that are built with potemkin (or are
-  ;; unparsable for other reasons) seems fine for the moment, for the
-  ;; purposes of the feature this code is providing.
-  (try
-    (form/count-vars-in-ns graph ns)
-    (catch Throwable _)))
+(defn ignore-exceptions
+  [f]
+  (fn [& args]
+    (try
+      (apply f args)
+      (catch Throwable _))))
+
+;; The `potemkin` library attempts to "fix" various clojure problems
+;; in ways that break the `macro-expand-1` call that `yagni`
+;; makes. (Code that this is scanning can use potemkin.) Ignoring
+;; namespaces that are built with potemkin (or are unparsable for
+;; other reasons) seems fine for the moment, for the purpose of the
+;; feature this code is providing.
+(alter-var-root #'form/count-vars-in-ns ignore-exceptions)
 
 (defn- call-graph
   "Returns the call graph of every var in each of the namespaces."
-  [namespaces]
+  [namespaces entry-points]
   ;; This is the same as `yagni.core/construct-reference-graph`, but
   ;; with a couple of tweaks:
   ;;  - Instead of acting on a directory, it acts on a list of namespaces
@@ -66,11 +84,11 @@
   (let [namespaces (->> (map ->sym namespaces)
                         (remove #{'clojure.core}))
         graph (atom (namesp/named-vars-map namespaces))
-        generator-fns (jvm/find-generator-fns graph)]
+        generator-fns (jvm/find-generator-fns graph)
+        entry-points (map ->var entry-points)]
     (jvm/extend-generators! graph generator-fns)
-    ;; (form/count-vars graph namespaces)
-    (doall (map (partial count-vars-in-ns graph) namespaces))
-    (graph/prune-findable-nodes! graph nil (atom #{}))
+    (form/count-vars graph namespaces)
+    (graph/prune-findable-nodes! graph entry-points (atom #{}))
     (jvm/compress-generators! graph generator-fns)
     @graph))
 
@@ -79,18 +97,66 @@
   [call-graph keys]
   (fn [[f]]
     (when (jukebox/scene-related? (->var f))
-      (when-let [fcg (flattened-call-graph f call-graph)]
+      (let [fcg (flattened-call-graph f call-graph)]
         (let [r (resources f keys)]
           [f (into (if r #{r} #{})
                    (keep #(resources % keys) fcg))])))))
+(defn parse-tags
+  "Parses the `--tags` command line option."
+  [cli-args]
+  (cucumber.runtime.RuntimeOptions. cli-args))
+
+(defn- pickle-steps
+  "Returns the list of `gherkin.pickle.PickleStep`s in the features
+  matching `tags`."
+  [tags]
+  (let [tags (or tags (cucumber.runtime.RuntimeOptions. []))
+        filters (cucumber.runtime.filter.Filters. tags)]
+   (->>
+    (-> (Thread/currentThread)
+        (.getContextClassLoader)
+        (MultiLoader.)
+        (FeatureLoader.)
+        (FeaturePathFeatureSupplier. tags)
+        (.get))
+    (mapcat #(.getPickles %))
+    (filter #(.matchesFilters filters %))
+    (mapcat #(.getSteps (.pickle %))))))
+
+(defn- step-definition-for-pickle-step
+  "Returns the step-definition that matches the `pickle-step."
+  [step-definitions pickle-step]
+  (:step-fn (first (filter #(.matchedArguments % pickle-step) step-definitions))))
+
+(defn- step-definitions
+  "Returns the step-definitions (clojure fn) matching `tags`."
+  [tags]
+  (let [definitions (cucumber/->definitions)
+        hooks (jukebox/hooks)]
+    (jukebox/register (cucumber/->CucumberJukeBackend definitions) hooks)
+
+    (let [step-definitions
+          (map
+           (fn [{:keys [pattern step-fn]}]
+             (cucumber/->JukeStepDefinition pattern step-fn (meta step-fn)))
+           (:steps @definitions))]
+
+      (->> (pickle-steps tags)
+           (map #(step-definition-for-pickle-step step-definitions %))
+           (concat (filter surrounding-step? hooks))
+           (map ->sym)
+           (into #{})))))
 
 (defn inventory
-  "Returns a map of entry points to inventory manifest.
-
-  Scans the paths for fn's with meta containing `keys` as entry
-  points. Then scans each's entrypoint's call graph transitively,
-  looking for fns also tagged with `keys` in their 'meta'."
-  [keys]
-  (let [cg (call-graph (all-ns))]
+  "Returns a map of entry points to inventory manifest for features matching `tags` (see `parse-tags`)."
+  [keys tags]
+  (let [entry-points (step-definitions tags)
+        cg (call-graph (all-ns) entry-points)
+        entry-points (into #{} (map symbol entry-points))]
     (->> (keep (manifest cg keys) cg)
+         (map (fn [[k v]]
+                [k (into #{} (map #(select-keys % keys) v))]))
+         (filter (fn [[k v]]
+                   (and (entry-points (->sym (resolve k)))
+                        (not= #{} v))))
          (into {}))))

--- a/test/example/belly.clj
+++ b/test/example/belly.clj
@@ -1,8 +1,45 @@
 (ns example.belly)
 
+(defn- helper-fn-a
+  "A test helper fn."
+  {:scene/resources [:kafka/topic "topic-name-a"]}
+  [])
+
+(defn- helper-fn-b
+  "A test helper fn."
+  {:scene/resources [:kafka/topic "topic-name-b"]}
+  [])
+
+(defn- helper-fn-c
+  "A test helper fn."
+  {:scene/resources [:kafka/topic "topic-name-c"]}
+  [])
+
+(defn- helper-fn-d
+  "A test helper fn."
+  {:scene/resources [:kafka/topic "topic-name-a"]}
+  []
+  (helper-fn-c))
+
+(defn- helper-fn-e
+  "A test helper fn."
+  []
+  '(helper-fn-e))
+
+(defn ^:scene/before before-step
+  "Called before a scenario."
+  {:scene/resources [:kafka/topic "topic-name-d"]}
+  [board scenario]
+  board)
+
 (defn i-have-cukes-in-my-belly
-  {:scene/step "I have {int} cukes in my belly"}
+  {:scene/step "I have {int} cukes in my belly"
+   :scene/resources [:kafka/topic "topic-name"]}
   [board number-of-cukes]
+  (helper-fn-a)
+  (helper-fn-b)
+  (helper-fn-d)
+  (helper-fn-e)
   board)
 
 (defn i-wait-hour

--- a/test/fundingcircle/jukebox/resource_test.clj
+++ b/test/fundingcircle/jukebox/resource_test.clj
@@ -1,0 +1,70 @@
+(ns fundingcircle.jukebox.resource-test
+  "Test resource inventory libary."
+  (:require [fundingcircle.jukebox.resource :as resource]
+            [clojure.test :refer [deftest is]]))
+
+;; These helper functions set up a call graph for the test below to cover these scenarios:
+;; * The inventory should include resources on transitive functions
+;; * The inventory should de-duplicate resources
+;; * Recursive calls don't result in a stack overflow
+;;
+;; entry-point
+;;   --> helper-fn-a
+;;   --> helper-fn-b
+;;   --> helper-fn-d
+;;     --> helper-fn-c (transitive scenario)
+;;   --> helper-fn-e
+;;     --> helper-fn-e (recursive scenario)
+
+(defn- helper-fn-a
+  "A test helper fn."
+  {:scene/resource-type :kafka-topic
+   :scene/resource-caps {:topic-name "topic-name-a"}}
+  [])
+
+(defn- helper-fn-b
+  "A test helper fn."
+  {:scene/resource-type :kafka-topic
+   :scene/resource-caps {:topic-name "topic-name-b"}}
+  [])
+
+(defn- helper-fn-c
+  "A test helper fn."
+  {:scene/resource-type :kafka-topic
+   :scene/resource-caps {:topic-name "topic-name-c"}}
+  [])
+
+(defn- helper-fn-d
+  "A test helper fn."
+  {:scene/resource-type :kafka-topic
+   :scene/resource-caps {:topic-name "topic-name-a"}}
+  []
+  (helper-fn-c))
+
+(defn- helper-fn-e
+  "A test helper fn."
+  []
+  (helper-fn-e))
+
+(defn entry-point
+  "A test entry point."
+  {:scene/step "test entry point"
+   :scene/resource-type :kafka-topic
+   :scene/resource-caps {:topic-name "topic-name"}}
+  [_]
+  (helper-fn-a)
+  (helper-fn-b)
+  (helper-fn-d)
+  (helper-fn-e))
+
+(deftest inventory-test
+  (is (= #{{:scene/resource-type :kafka-topic
+            :scene/resource-caps {:topic-name "topic-name"}}
+           {:scene/resource-type :kafka-topic
+            :scene/resource-caps {:topic-name "topic-name-c"}}
+           {:scene/resource-type :kafka-topic
+            :scene/resource-caps {:topic-name "topic-name-a"}}
+           {:scene/resource-type :kafka-topic
+            :scene/resource-caps {:topic-name "topic-name-b"}}}
+       (`entry-point
+        (resource/inventory ["test"])))))

--- a/test/fundingcircle/jukebox/resource_test.clj
+++ b/test/fundingcircle/jukebox/resource_test.clj
@@ -1,7 +1,7 @@
 (ns fundingcircle.jukebox.resource-test
   "Test resource inventory libary."
-  (:require [fundingcircle.jukebox.resource :as resource]
-            [clojure.test :refer [deftest is]]))
+  (:require [clojure.test :refer [deftest is testing]]
+            [fundingcircle.jukebox.resource :as resource]))
 
 ;; These helper functions set up a call graph for the test below to cover these scenarios:
 ;; * The inventory should include resources on transitive functions
@@ -16,57 +16,19 @@
 ;;   --> helper-fn-e
 ;;     --> helper-fn-e (recursive scenario)
 
-(defn- helper-fn-a
-  "A test helper fn."
-  {:scene/resource-type :kafka-topic
-   :scene/resource-caps {:topic-name "topic-name-a"}}
-  [])
-
-(defn- helper-fn-b
-  "A test helper fn."
-  {:scene/resource-type :kafka-topic
-   :scene/resource-caps {:topic-name "topic-name-b"}}
-  [])
-
-(defn- helper-fn-c
-  "A test helper fn."
-  {:scene/resource-type :kafka-topic
-   :scene/resource-caps {:topic-name "topic-name-c"}}
-  [])
-
-(defn- helper-fn-d
-  "A test helper fn."
-  {:scene/resource-type :kafka-topic
-   :scene/resource-caps {:topic-name "topic-name-a"}}
-  []
-  (helper-fn-c))
-
-(defn- helper-fn-e
-  "A test helper fn."
-  []
-  (helper-fn-e))
-
-(defn entry-point
-  "A test entry point."
-  {:scene/step "test entry point"
-   :scene/resource-type :kafka-topic
-   :scene/resource-caps {:topic-name "topic-name"}}
-  [_]
-  (helper-fn-a)
-  (helper-fn-b)
-  (helper-fn-d)
-  (helper-fn-e))
+(require 'example.belly) ;; be sure the instrumented fns are loaded
 
 (deftest inventory-test
-  (is (= #{{:scene/resource-type :kafka-topic
-            :scene/resource-caps {:topic-name "topic-name"}}
-           {:scene/resource-type :kafka-topic
-            :scene/resource-caps {:topic-name "topic-name-c"}}
-           {:scene/resource-type :kafka-topic
-            :scene/resource-caps {:topic-name "topic-name-a"}}
-           {:scene/resource-type :kafka-topic
-            :scene/resource-caps {:topic-name "topic-name-b"}}}
-         (->> (resource/inventory [:scene/resource-type])
-              (`entry-point)
-              (map #(select-keys % [:scene/resource-type :scene/resource-caps]))
-              (into #{})))))
+  (testing "resource inventory"
+    
+    (let [inventory (resource/inventory [:scene/resources]
+                                        (resource/parse-tags ["test/features"]))]
+      (is (= {'example.belly/i-have-cukes-in-my-belly
+              #{{:scene/resources [:kafka/topic "topic-name"]}
+                {:scene/resources [:kafka/topic "topic-name-a"]}
+                {:scene/resources [:kafka/topic "topic-name-b"]}
+                {:scene/resources [:kafka/topic "topic-name-c"]}}
+              'example.belly/before-step
+              #{{:scene/resources [:kafka/topic "topic-name-d"]}}}
+             inventory)))))
+

--- a/test/fundingcircle/jukebox/resource_test.clj
+++ b/test/fundingcircle/jukebox/resource_test.clj
@@ -66,5 +66,7 @@
             :scene/resource-caps {:topic-name "topic-name-a"}}
            {:scene/resource-type :kafka-topic
             :scene/resource-caps {:topic-name "topic-name-b"}}}
-       (`entry-point
-        (resource/inventory ["test"])))))
+         (->> (resource/inventory [:scene/resource-type])
+              (`entry-point)
+              (map #(select-keys % [:scene/resource-type :scene/resource-caps]))
+              (into #{})))))


### PR DESCRIPTION
## Motivation
End to end tests run in environments that have the systems under test installed along with supporting infrastructure. We want to be able to automatically install the right services (on ephemeral environments) and validate the services when running tests against persistent environments. Manually maintaining scenario-specific service inventories for health checks isn't manageable as the test coverage grows, and more tests are composed from shared step definitions / helper functions.

## Feature
This adds a feature that allows functions in the test code to be tagged with a resource they need, by adding the keys `:scene/resource-type` and `:scene/resource-caps`(capabilities) to the function's metadata.

For example:
```
(defn entry-point
  "A step definition."
  {:scene/step "test entry point"
   :scene/resources [:kafka/topic "topic-name]}
  [_])
```

There is a single public API function `(resource/inventory source-paths)`. This scans the source paths for step definitions, and return a map of step definitions to resource inventory. Here's an example inventory that includes `entry-point`.

```
{'example.belly/i-have-cukes-in-my-belly
          #{{:scene/resources [:kafka/topic "topic-name"]}
            {:scene/resources [:kafka/topic "topic-name-a"]}
            {:scene/resources [:kafka/topic "topic-name-b"]}
            {:scene/resources [:kafka/topic "topic-name-c"]}}}
```

A resource doesn't need to be tagged on a step definition function directly - the step function's call graph is scanned transitively to collate an inventory that includes resources tagged on any helper function. The inventory is a flat, de-duplicated list of all resources that are needed by any function used in the step.

The _values_ of `:scene/resource-type` and `:scene/resource-caps` can be anything. The `(resources/inventory)` just collects the inventory of tags. It's up to the code calling `(resources/inventory)` to interpret with those, if needed, based on the context within which the tests are being written.

## Possible Uses
The API `(resource/inventory)` would be used together with other jukebox features (such as within a `:scene/before` or `:scene/after` callback). Some possible uses:
* Inflate/install the data and services needed for a specific scenario on an ephemeral environment.
* Run quick health checks to validate the resources before running the tests. If we know what services are needed at the end of a test run, we can check early that it's up.
* Surround step definitions with environment validation.
* If a test fails, run more detailed health checks against the inventory for more details, such as pulling services' logs.

## Further discussion
A few notes that could use some further discussion:
* The code is admittedly dense ("repl driven"), and could be rewritten for clarity.
* It supports tagging a function with a single resource (not more). This is probably sufficient for well-organized test code, but perhaps we should allow a function to be tagged with a list of resources it uses.
* The mechanism could be generalized - so for example, instead of scanning specifically for `:scene/resource-*` tags, the list could be provided as a parameter to `(resource/inventory)`. This would open up the general meta scanning capability to future (unknown) use cases.
* We should remove the `(select-keys [:scene/resource-*`])` against the fn meta. Passing along whatever's there into the inventory will allow library users to add extra tags they need.