### PR TITLE
Support re-running Cucumber at the REPL

### DIFF
--- a/src/fundingcircle/jukebox/backend/cucumber.clj
+++ b/src/fundingcircle/jukebox/backend/cucumber.clj
@@ -259,11 +259,11 @@
 
 (defn- -loadGlue [this glue glue-paths]
   (log/debugf "Glue paths: %s" glue-paths)
+  (swap! definitions set-glue glue)
   (if (= 0 (count glue-paths))
     (jukebox/register jukebox-backend (jukebox/hooks))
     (doseq [glue-path glue-paths]
-      (jukebox/register jukebox-backend (jukebox/hooks glue-path))))
-  (swap! definitions set-glue glue))
+      (jukebox/register jukebox-backend (jukebox/hooks glue-path)))))
 
 (defn- -buildWorld [_]
   (reset! world {::world? true}))


### PR DESCRIPTION
You can now update step defs, reload the namespaces and run this multiple times successfully:

```
(Main/run (into-array ["--plugin" "pretty"
                             "--glue" "test"
                             "test/features"])
                (.getContextClassLoader (Thread/currentThread)))
```

Without this commit, Cucumber complains about step definitions being duplicated.
Actually, the glue can change between  2 invocations of the `loadGlue` method by the framework, so we first store the glue passed in parameter in the `definitions` atom.
