### PR TITLE
Replace log4j with logback

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,5 +12,6 @@
                                          "--glue" "test/example"
                                          "--plugin" "json:cucumber.json"
                                          "--plugin" "pretty"
-                                         "test/features"]}}}
+                                         "test/features"]}
+                   :dependencies [[ch.qos.logback/logback-classic "1.2.3"]]}}
   :aot [fundingcircle.jukebox.backend.cucumber])

--- a/test/log4j.properties
+++ b/test/log4j.properties
@@ -1,5 +1,0 @@
-log4j.rootLogger=INFO, console
-log4j.logger.example=DEBUG
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%-5p %c: %m%n

--- a/test/logback.xml
+++ b/test/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Logging didn't work, as no log4j jar was on the classpath.
This PR switches to Logback, adds `logback-classic` to the `dev` profile  and a default `logback.xml` configuration that enables only INFO level logs. 