### PR TITLE
Don't log an error if no difference between provides state and step s…

### DIFF
--- a/src/fundingcircle/jukebox/backend/cucumber.clj
+++ b/src/fundingcircle/jukebox/backend/cucumber.clj
@@ -124,7 +124,7 @@
                               (map process-arg args))
               expected-fixtures (set (keys expected))
               missing (set/difference expected-fixtures (set (keys @world)))]
-          (when missing
+          (when-not (empty? missing)
             (log/errorf "Expected step to provide fixures, but they are missing: %s" missing))))
 
       (catch Throwable e


### PR DESCRIPTION
…tate

Applying `when` with an empty set as the test will still evaluate to logical true, causing an error to be logged even if the provides contract has been upheld.